### PR TITLE
fix:highlight.jsの呼び出しミスでエラーが発生していたので修正

### DIFF
--- a/src/main/resources/templates/user/project/index.html
+++ b/src/main/resources/templates/user/project/index.html
@@ -86,12 +86,14 @@
 <script src="../../../static/js/highlight.pack.js" th:src="@{/js/highlight.pack.js}"></script>
 <script th:inline="javascript">
   $(function () {
+	  
     //marked.js
     marked.setOptions({
       highlight: function(code, lang) {
-        return hljs.highlightAuto(code, lang).value;
+        return hljs.highlightAuto(code, [lang]).value;
       }
     });
+    
 
 
     $('#readme').html(marked([[${readme}]]));

--- a/src/main/resources/templates/user/project/index.html
+++ b/src/main/resources/templates/user/project/index.html
@@ -89,6 +89,7 @@
 	  
     //marked.js
     marked.setOptions({
+      sanitize:true,
       highlight: function(code, lang) {
         return hljs.highlightAuto(code, [lang]).value;
       }

--- a/src/main/resources/templates/user/project/ticket-detail.html
+++ b/src/main/resources/templates/user/project/ticket-detail.html
@@ -134,6 +134,7 @@
 
     //marked.js
     marked.setOptions({
+      sanitize:true,
       highlight: function(code, lang) {
         return hljs.highlightAuto(code, [lang]).value;
       }

--- a/src/main/resources/templates/user/project/ticket-detail.html
+++ b/src/main/resources/templates/user/project/ticket-detail.html
@@ -135,7 +135,7 @@
     //marked.js
     marked.setOptions({
       highlight: function(code, lang) {
-        return hljs.highlightAuto(code, lang).value;
+        return hljs.highlightAuto(code, [lang]).value;
       }
     });
 


### PR DESCRIPTION
highlight.jsとのインターフェースが合っておらず
下記の変更前の処理でエラーが発生していたので変更しました。
（※コードブロックで言語指定がある場合落ちていた模様？）
# 変更前

``` js
    //marked.js
    marked.setOptions({
      highlight: function(code, lang) {
        return hljs.highlightAuto(code, lang).value;
      }
    });
```
# 変更後

``` js
    marked.setOptions({
      highlight: function(code, lang) {
        return hljs.highlightAuto(code, [lang]).value;
      }
    });
```

※テストで食わせたmarkdownはkobitoのmarkdownチートシート
https://gist.github.com/Wreulicke/dd8c0b74d07f5cdd6627330b56eb76ce
