### PR TITLE
Push activityの作成

### DIFF
--- a/src/main/java/net/orekyuu/gitthrow/activity/usecase/ActivityUsecase.java
+++ b/src/main/java/net/orekyuu/gitthrow/activity/usecase/ActivityUsecase.java
@@ -74,6 +74,10 @@ public class ActivityUsecase {
             mergedPullRequest.getProponent(), project);
     }
 
+    public Activity createPushActivity(Project project, User user) {
+        return create("リポジトリにpushしました", String.format("project: %s", project.getName()), user, project);
+    }
+
     @Transactional(readOnly = false)
     private Activity create(String title, String desc, User user, Project project) {
         logger.info("[Activity] create: title=%s, desc=%s, user=%s, project=%s", title, desc, user.getId(), project.getId());

--- a/src/main/java/net/orekyuu/gitthrow/activity/usecase/ActivityUsecase.java
+++ b/src/main/java/net/orekyuu/gitthrow/activity/usecase/ActivityUsecase.java
@@ -75,7 +75,7 @@ public class ActivityUsecase {
     }
 
     public Activity createPushActivity(Project project, User user) {
-        return create("リポジトリにpushしました", String.format("project: %s", project.getName()), user, project);
+        return create("リポジトリにpushしました", String.format("user: %s", user.getName()), user, project);
     }
 
     @Transactional(readOnly = false)

--- a/src/main/java/net/orekyuu/gitthrow/config/git/GitActivityFilter.java
+++ b/src/main/java/net/orekyuu/gitthrow/config/git/GitActivityFilter.java
@@ -33,13 +33,13 @@ public class GitActivityFilter implements Filter {
     }
 
     @Override
-    public void destroy() {
-    }
+    public void destroy() {}
 
     @Override
     public void doFilter(ServletRequest servletRequest, ServletResponse servletResponse, FilterChain filterChain) throws IOException,
         ServletException {
 
+        filterChain.doFilter(servletRequest, servletResponse);
         HttpServletRequest req = (HttpServletRequest) servletRequest;
         HttpServletResponse res = (HttpServletResponse) servletResponse;
 
@@ -50,26 +50,27 @@ public class GitActivityFilter implements Filter {
             return;
         }
 
-        String decodeHeader = decode(authorization);
-        String[] split = decodeHeader.split(":");
-        String userName = split[0];
-        String uri = req.getRequestURI();
-        String uri2 = uri.substring("/git/repos/".length());
-        if (uri2.indexOf("git-receive-pack") > 0) {
-            UserUsecase userUsecase = context.getBean(UserUsecase.class);
-            Optional<User> userOpt = userUsecase.findById(userName);
-            ActivityUsecase activityUsecase = context.getBean(ActivityUsecase.class);
-            String[] temp = uri2.split("/");
-            String projectId = temp[0];
-            ProjectUsecase projectUsecase = context.getBean(ProjectUsecase.class);
-            projectUsecase.findById(projectId)
-                .ifPresent((project) -> {
-                    userOpt.ifPresent((user) -> {
-                        activityUsecase.createPushActivity(project, user);
+        if (res.getStatus() == 200) {
+            String decodeHeader = decode(authorization);
+            String[] split = decodeHeader.split(":");
+            String userName = split[0];
+            String uri = req.getRequestURI();
+            String uri2 = uri.substring("/git/repos/".length());
+            if (uri2.indexOf("git-receive-pack") > 0) {
+                UserUsecase userUsecase = context.getBean(UserUsecase.class);
+                Optional<User> userOpt = userUsecase.findById(userName);
+                ActivityUsecase activityUsecase = context.getBean(ActivityUsecase.class);
+                String[] temp = uri2.split("/");
+                String projectId = temp[0];
+                ProjectUsecase projectUsecase = context.getBean(ProjectUsecase.class);
+                projectUsecase.findById(projectId)
+                    .ifPresent((project) -> {
+                        userOpt.ifPresent((user) -> {
+                            activityUsecase.createPushActivity(project, user);
+                        });
                     });
-                });
+            }
         }
-        filterChain.doFilter(servletRequest, servletResponse);
     }
 
 
@@ -80,7 +81,6 @@ public class GitActivityFilter implements Filter {
     }
 
     @Override
-    public void init(FilterConfig config) throws ServletException {
-    }
+    public void init(FilterConfig config) throws ServletException {}
 
 }

--- a/src/main/java/net/orekyuu/gitthrow/config/git/GitActivityFilter.java
+++ b/src/main/java/net/orekyuu/gitthrow/config/git/GitActivityFilter.java
@@ -1,0 +1,86 @@
+package net.orekyuu.gitthrow.config.git;
+
+import java.io.IOException;
+import java.util.Base64;
+import java.util.Optional;
+
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.FilterConfig;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.ApplicationContext;
+
+import net.orekyuu.gitthrow.activity.usecase.ActivityUsecase;
+import net.orekyuu.gitthrow.project.usecase.ProjectUsecase;
+import net.orekyuu.gitthrow.user.domain.model.User;
+import net.orekyuu.gitthrow.user.usecase.UserUsecase;
+
+public class GitActivityFilter implements Filter {
+    private ApplicationContext context;
+
+    private static final String AUTH_HEADER_NAME = "WWW-Authenticate";
+    private static final String AUTH_HEADER_VALUE = "BASIC realm=\"Workbench\"";
+
+    public GitActivityFilter(ApplicationContext context) {
+        this.context = context;
+    }
+
+    @Override
+    public void destroy() {
+    }
+
+    @Override
+    public void doFilter(ServletRequest servletRequest, ServletResponse servletResponse, FilterChain filterChain) throws IOException,
+        ServletException {
+
+        HttpServletRequest req = (HttpServletRequest) servletRequest;
+        HttpServletResponse res = (HttpServletResponse) servletResponse;
+
+        String authorization = req.getHeader("Authorization");
+        if (authorization == null) {
+            res.addHeader(AUTH_HEADER_NAME, AUTH_HEADER_VALUE);
+            res.sendError(401);
+            return;
+        }
+
+        String decodeHeader = decode(authorization);
+        String[] split = decodeHeader.split(":");
+        String userName = split[0];
+        String uri = req.getRequestURI();
+        String uri2 = uri.substring("/git/repos/".length());
+        if (uri2.indexOf("git-receive-pack") > 0) {
+            UserUsecase userUsecase = context.getBean(UserUsecase.class);
+            Optional<User> userOpt = userUsecase.findById(userName);
+            ActivityUsecase activityUsecase = context.getBean(ActivityUsecase.class);
+            String[] temp = uri2.split("/");
+            String projectId = temp[0];
+            ProjectUsecase projectUsecase = context.getBean(ProjectUsecase.class);
+            projectUsecase.findById(projectId)
+                .ifPresent((project) -> {
+                    userOpt.ifPresent((user) -> {
+                        activityUsecase.createPushActivity(project, user);
+                    });
+                });
+        }
+        filterChain.doFilter(servletRequest, servletResponse);
+    }
+
+
+    private String decode(String authorizationHeader) {
+        String str = authorizationHeader.substring("BASIC ".length());
+        return new String(Base64.getDecoder()
+            .decode(str));
+    }
+
+    @Override
+    public void init(FilterConfig config) throws ServletException {
+    }
+
+}

--- a/src/main/java/net/orekyuu/gitthrow/config/git/GitConfig.java
+++ b/src/main/java/net/orekyuu/gitthrow/config/git/GitConfig.java
@@ -33,4 +33,13 @@ public class GitConfig {
         registration.setName("gitAuthFilter");
         return registration;
     }
+
+    @Bean
+    public FilterRegistrationBean gitFilter() {
+        FilterRegistrationBean registration = new FilterRegistrationBean();
+        registration.setFilter(new GitActivityFilter(context));
+        registration.addUrlPatterns("/git/repos/*");
+        registration.setName("gitActivityFilter");
+        return registration;
+    }
 }


### PR DESCRIPTION
# 実装方針

Filterでpushのリクエストか確認して、そうであればActivityを登録する。
実際にpushされる際、/git/repos/${repositoryName}/git-receive-packにリクエストが飛んでくる。

この時に以下のステップでアクティビティを作成する
1. リクエストヘッダからユーザIdを取得(BASIC認証)
2. リクエストURIからプロジェクトIdを取得
3. プロジェクト・ユーザが存在するならアクティビティを生成

（その以前のアクセスでハンドシェイクをしているのかgetParameter("service") == git-receive-packになる）

# レビューしてほしい点・他気になる点

1. Filterで実装以外で他に方法ってありますかね
2. decode処理コピペになってるので、どっかに切り出す？
3. Optional周りのネスト

ref #85 

とりあえず書いたので気になるところあれば直します～